### PR TITLE
Fully working gallery example scripts and accompanying updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ PyGLImER.egg-info/
 .idea/
 ccp*.pkl
 .coverage
+examples/tutorials/database_hdf5
+examples/tutorials/database_sac

--- a/examples/tutorials/DataCollectionHDF5.py
+++ b/examples/tutorials/DataCollectionHDF5.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 """
-Collection Data in the HDF5 
-===========================
+HDF5 Database
+=============
 
 This example is nearly identical to the MSEED tutorial except the fact that we
 are specifying a different data format in the request dictionary.
@@ -132,7 +132,7 @@ print(f"Number of downloaded waveforms: {len(stream)}")
 # %%
 # The final step to get you receiver function data is the preprocessing. 
 # Although it is hidden in a single function, which
-# is :function:`:func:`pyglimer.waveform.request.Request.preprocess`
+# is :func:`pyglimer.waveform.request.Request.preprocess`
 # A lot of decisions are being made:
 #
 # Processing steps:
@@ -141,22 +141,21 @@ print(f"Number of downloaded waveforms: {len(stream)}")
 # 2. Demean & Detrend
 # 3. Tapering
 # 4. Remove Instrument response, convert to velocity &
-#    simulate havard station
+# simulate havard station
 # 5. Rotation to NEZ and, subsequently, to RTZ.
 # 6. Compute SNR for highpass filtered waveforms (highpass f defined in 
-#    qc.lowco) If SNR lower than in qc.SNR_criteria for all filters, rejects w
-#    aveform.
+# qc.lowco) If SNR lower than in qc.SNR_criteria for all filters, rejects 
+# waveform.
 # 7. Write finished and filtered waveforms to folder
-#    specified in qc.outputloc.
+# specified in qc.outputloc.
 # 8. Write info file with shelf containing station,
-#    event and waveform information.
+# event and waveform information.
 # 9. (Optional) If we had chosen a different coordinate system in ``rot``
-#    than RTZ, it would now cast the preprocessed waveforms information
-#    that very coordinate system.
+# than RTZ, it would now cast the preprocessed waveforms information
+# that very coordinate system.
 # 10. Deconvolution with method ``deconmeth`` from our dict is perfomed.
-#    
-# It again uses the request class to perform this. The ``if __name__ ...``
-# expression is needed for running this examples
+#
+
 R.preprocess(hc_filt=1.5, client='single')
 
 # %% Read the IU-HRV receiver functions as a Receiver function stream

--- a/examples/tutorials/DataCollectionMSEED.py
+++ b/examples/tutorials/DataCollectionMSEED.py
@@ -31,7 +31,7 @@ information. Let's look at the expected information:
 # First let's get a path where to create the data.
 
 # Some needed Imports
-import os, logging
+import os
 from obspy import UTCDateTime
 from pyglimer.waveform.request import Request
 
@@ -60,7 +60,7 @@ request_dict = {
     "deconmeth": "waterlevel",    # Deconvolution method
     "starttime": UTCDateTime(2021, 1, 1, 0, 0, 0), # Starttime of database.
                                                    # Here, starttime of HRV
-    "endtime": UTCDateTime.now(), # Endtimetime of database
+    "endtime": UTCDateTime(2021, 7, 1, 0, 0, 0), # Endtimetime of database
     # kwargs below
     "pol": 'v',                   # Source wavelet polaristion. Def. "v" --> SV
     "minmag": 5.5,                # Earthquake minimum magnitude. Def. 5.5
@@ -122,9 +122,6 @@ print(f"There are {len(R.evtcat)} available events")
 # ***NOTE:*** This might take a while.
 # 
 
-# Station dir 
-station_dir = os.path.join(proj_dir, 'stations')
-if not os.path.exists(station_dir): os.mkdir()
 
 print('downloading')
 R.download_waveforms_small_db(channel='BH?')

--- a/examples/tutorials/DataCollectionMSEED.py
+++ b/examples/tutorials/DataCollectionMSEED.py
@@ -30,6 +30,7 @@ information. Let's look at the expected information:
 # %%
 # First let's get a path where to create the data.
 
+
 # Some needed Imports
 import os
 from obspy import UTCDateTime
@@ -59,7 +60,7 @@ request_dict = {
     "rot": "RTZ",                 # Coordinate system to rotate to
     "deconmeth": "waterlevel",    # Deconvolution method
     "starttime": UTCDateTime(2021, 1, 1, 0, 0, 0), # Starttime of database.
-                                                   # Here, starttime of HRV
+                                                # Here, starttime of HRV
     "endtime": UTCDateTime(2021, 7, 1, 0, 0, 0), # Endtimetime of database
     # kwargs below
     "pol": 'v',                   # Source wavelet polaristion. Def. "v" --> SV
@@ -69,7 +70,7 @@ request_dict = {
     "station": "HRV",             # Restricts stations. Def. None
     "waveform_client": ["IRIS"],  # FDSN server client (s. obspy). Def. None
     "evtcat": None,               # If you have already downloaded a set of
-                                  # events previously, you can use them here
+                                # events previously, you can use them here
     "loglvl": 'DEBUG'
 }
 
@@ -196,6 +197,7 @@ print(f"Number of RFs: {len(rfstream)}")
 
 # %% 
 # PyGLImER is based on Obspy, but to handle RFs we need some more attributes: 
+
 from pprint import pprint
 
 rftrace = rfstream[0]
@@ -219,6 +221,7 @@ pprint(rftrace.stats)
 # Below we show how to plot the receiver function
 # as a function of time, and the clean option, which plots
 # the receiver function without any axes or text.
+
 from pyglimer.plot.plot_utils import set_mpl_params
 
 # Plot RF

--- a/examples/tutorials/DataCollectionSAC.py
+++ b/examples/tutorials/DataCollectionSAC.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 """
-Collection Data in the MSEED 
-============================
+SAC Database
+============
 
 In this Tutorial we are going to get all good receiver functions for the year
 2018 for station IU-HRV ([Adam Dziewonski
@@ -139,8 +139,9 @@ data_storage = os.path.join(
 print(f"Number of downloaded waveforms: {len(glob(data_storage))}")
 
 # %%
-# The final step to get you receiver function data is the preprocessing. Although it is hidden in a single function, which
-# is :function:`:func:`pyglimer.waveform.request.Request.preprocess`
+# The final step to get you receiver function data is the preprocessing. 
+# Although it is hidden in a single function, which
+# is :func:`pyglimer.waveform.request.Request.preprocess`
 # A lot of decisions are being made:
 #
 # Processing steps:
@@ -149,20 +150,20 @@ print(f"Number of downloaded waveforms: {len(glob(data_storage))}")
 # 2. Demean & Detrend
 # 3. Tapering
 # 4. Remove Instrument response, convert to velocity &
-#    simulate havard station
+# simulate havard station
 # 5. Rotation to NEZ and, subsequently, to RTZ.
 # 6. Compute SNR for highpass filtered waveforms (highpass f defined in 
-#    qc.lowco) If SNR lower than in qc.SNR_criteria for all filters, rejects w
-#    aveform.
+# qc.lowco) If SNR lower than in qc.SNR_criteria for all filters, rejects 
+# waveform.
 # 7. Write finished and filtered waveforms to folder
-#    specified in qc.outputloc.
+# specified in qc.outputloc.
 # 8. Write info file with shelf containing station,
-#    event and waveform information.
+# event and waveform information.
 # 9. (Optional) If we had chosen a different coordinate system in ``rot``
-#    than RTZ, it would now cast the preprocessed waveforms information
-#    that very coordinate system.
+# than RTZ, it would now cast the preprocessed waveforms information
+# that very coordinate system.
 # 10. Deconvolution with method ``deconmeth`` from our dict is perfomed.
-#    
+#
 # It again uses the request class to perform this. The ``if __name__ ...``
 # expression is needed for running this examples
 

--- a/examples/tutorials/DataCollectionSAC.py
+++ b/examples/tutorials/DataCollectionSAC.py
@@ -1,0 +1,264 @@
+#!/bin/env python
+"""
+Collection Data in the MSEED 
+============================
+
+In this Tutorial we are going to get all good receiver functions for the year
+2018 for station IU-HRV ([Adam Dziewonski
+Observatory](http://www.seismology.harvard.edu/hrv.html)).
+
+To Compute the receiver function we need to download and organize the observed
+data. PyGLImER will automatically take car of these things for you in the
+background, but do check out the 'Database Docs' if you aren't familiar.
+
+Downloading Event & Station Metadata
+------------------------------------
+
+To download the data we use the :class:`pyglimer.waveform.request.Request`
+class. The first method from this class that we are going to use is the download
+event catalog public method
+:func:`pyglimer.waveform.request.Request.download_evtcat`, to get a set
+of events that contains all wanted earthquakes. This method is launched
+automatically upon initialization.
+
+To initialize said `class` we setup a parameter dictionary, with all the needed
+information. Let's look at the expected information:
+
+"""
+# sphinx_gallery_thumbnail_number = 1
+# sphinx_gallery_dummy_images = 1
+
+# %%
+# First let's get a path where to create the data.
+
+
+# Some needed Imports
+import os
+from obspy import UTCDateTime
+from pyglimer.waveform.request import Request
+
+# Get notebook path for future reference of the database:
+try: db_base_path = ipynb_path
+except NameError: db_base_path = os.getcwd()
+
+# Define file locations
+proj_dir = os.path.join(db_base_path, 'database_sac')
+
+
+
+request_dict = {
+    # Necessary arguments
+    'proj_dir': proj_dir,
+    'raw_subdir': 'waveforms/raw', # Directory of the waveforms
+    'prepro_subdir': 'waveforms/preprocessed',  # Directory of the preprocessed waveforms
+    'rf_subdir': 'waveforms/RF',  # Directory of the receiver functions
+    'statloc_subdir': 'stations', # Directory stations
+    'evt_subdir': 'events',       # Directory of the events
+    'log_subdir': 'log',          # Directory for the logs
+    'loglvl': 'WARNING',          # logging level
+    'format': 'sac',              # Format to save database in
+    "phase": "P",                 # 'P' or 'S' receiver functions
+    "rot": "RTZ",                 # Coordinate system to rotate to
+    "deconmeth": "waterlevel",    # Deconvolution method
+    "starttime": UTCDateTime(2021, 1, 1, 0, 0, 0), # Starttime of database.
+                                                # Here, starttime of HRV
+    "endtime": UTCDateTime(2021, 7, 1, 0, 0, 0), # Endtimetime of database
+    # kwargs below
+    "pol": 'v',                   # Source wavelet polaristion. Def. "v" --> SV
+    "minmag": 5.5,                # Earthquake minimum magnitude. Def. 5.5
+    "event_coords": None,         # Specific event?. Def. None
+    "network": "IU",              # Restricts networks. Def. None
+    "station": "HRV",             # Restricts stations. Def. None
+    "waveform_client": ["IRIS"],  # FDSN server client (s. obspy). Def. None
+    "evtcat": None,               # If you have already downloaded a set of
+                                  # events previously, you can use them here
+    "loglvl": 'DEBUG'
+}
+
+# %%
+# Now that all parameters are in place, let's initialize the 
+# :class:`pyglimer.waveform.request.Request`
+
+# Initializing the Request class and downloading the data
+R = Request(**request_dict)
+
+# %%
+# The initialization will look for all events for which data is available. To see 
+# whether the events make sense we plot a map of the events:
+
+import matplotlib.pyplot as plt
+from pyglimer.plot.plot_utils import plot_catalog
+from pyglimer.plot.plot_utils import set_mpl_params
+
+# Setting plotting parameters
+set_mpl_params()
+
+# Plotting the catalog
+plot_catalog(R.evtcat)
+
+# %%
+# We can also quickly check how many events we gathered.
+
+print(f"There are {len(R.evtcat)} available events")
+
+# %%
+# Downloading waveform data and station information
+# -------------------------------------------------
+#
+# The next step on our journey to receiver functions is retrieving
+# the corresponding waveform data.
+# To retrieve the waveform data, we can two different public methods
+# of `Request`: `download_waveforms()` or, as in this case `download_waveforms_small_db()`.
+# 
+# Both methods use the station and event locations to get viable
+# records of receiver function depending on epicentral distance and
+# traveltimes.
+# 
+# `download_waveforms()` relies on obspy's massdownloader and is best suited for
+# extremely large databases (i.e., from many different networks and stations).
+# `download_waveforms_small_db()` is faster for downloads from few stations and, additionally,
+# has the advantage that the desired networks and stations can be defined as lists and not only
+# as strings. Note that this method requires you to define the channels, you'd like to download
+# (as a string, wildcards allowed).
+# 
+# ***NOTE:*** This might take a while.
+# 
+
+R.download_waveforms_small_db(channel='BH?')
+
+# %%
+# Let's have a quick look at how many miniseeds we actually downloaded.
+
+from glob import glob
+
+# Path to the where the miniseeds are stored
+data_storage = os.path.join(
+    proj_dir, 'waveforms','raw','P','**', '*.mseed')
+
+# Print output
+print(f"Number of downloaded waveforms: {len(glob(data_storage))}")
+
+# %%
+# The final step to get you receiver function data is the preprocessing. Although it is hidden in a single function, which
+# is :function:`:func:`pyglimer.waveform.request.Request.preprocess`
+# A lot of decisions are being made:
+#
+# Processing steps:
+# 1. Clips waveform to the right length (tz before and ta after theorethical 
+# arrival.)
+# 2. Demean & Detrend
+# 3. Tapering
+# 4. Remove Instrument response, convert to velocity &
+#    simulate havard station
+# 5. Rotation to NEZ and, subsequently, to RTZ.
+# 6. Compute SNR for highpass filtered waveforms (highpass f defined in 
+#    qc.lowco) If SNR lower than in qc.SNR_criteria for all filters, rejects w
+#    aveform.
+# 7. Write finished and filtered waveforms to folder
+#    specified in qc.outputloc.
+# 8. Write info file with shelf containing station,
+#    event and waveform information.
+# 9. (Optional) If we had chosen a different coordinate system in ``rot``
+#    than RTZ, it would now cast the preprocessed waveforms information
+#    that very coordinate system.
+# 10. Deconvolution with method ``deconmeth`` from our dict is perfomed.
+#    
+# It again uses the request class to perform this. The ``if __name__ ...``
+# expression is needed for running this examples
+
+R.preprocess(hc_filt=1.5, client='single')
+
+# %%
+# First Receiver functions
+# ------------------------
+# 
+# The following few section show how to plot 
+# 
+# 1. Single raw RFs
+# 2. A set of raw RFs
+# 3. A move-out corrected RF
+# 4. A set of move-out corrected RFs
+#
+# 
+# Read the IU-HRV receiver functions as a Receiver function stream
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# 
+# Let's read a receiver function set and see what it's all about! 
+# (i.e. let's look at what data a Receiver function trace contains
+# and how we can use it!)
+
+from pyglimer.rf.create import read_rf
+
+path_to_rf = os.path.join(proj_dir, 'waveforms','RF','P','IU','HRV','*.sac')
+rfstream = read_rf(path_to_rf)
+
+print(f"Number of RFs: {len(rfstream)}")
+
+# %% 
+# PyGLImER is based on Obspy, but to handle RFs we need some more attributes: 
+
+from pprint import pprint
+
+rftrace = rfstream[0]
+pprint(rftrace.stats)
+
+
+# %%
+# First Receiver function plots
+# -----------------------------
+# 
+# If the Receiver functions haven't been further processed,
+# they are plotted as a function of time. A single receiver
+# function in the stream will be plotted as function of time
+# only. A full stream can make use of the distance measure saved
+# in the sac-header and plot an entire section as a function of
+# time and epicentral distance.
+#
+# Plot single RF
+# ++++++++++++++
+#
+# Below we show how to plot the receiver function
+# as a function of time, and the clean option, which plots
+# the receiver function without any axes or text.
+
+from pyglimer.plot.plot_utils import set_mpl_params
+
+# Plot RF
+rftrace.plot()
+
+# %% 
+# Let's zoom into the first 20 seconds (~200km)
+
+rftrace.plot(lim=[0,20])
+
+# %% 
+# Plot RF section
+# +++++++++++++++
+#
+# Since we have an entire stream of receiver functions at hand,
+# we can plot a section
+
+rfstream.plot(scalingfactor=1)
+
+# %% 
+# Similar to the single RF plot we can provide time and 
+# epicentral distance limits:
+
+timelimits = (0, 20)  # seconds  
+epilimits = (32, 36)  # epicentral distance
+rfstream.plot(
+    scalingfactor=0.25, lim=timelimits, epilimits=epilimits,
+    linewidth=0.75)
+
+# %%
+# By increasing the scaling factor and removing the plotted lines, we can
+# already see trends:
+
+rfstream.plot(
+    scalingfactor=0.5, lim=timelimits, epilimits=epilimits, 
+    line=False)
+
+
+# %% 
+# As simple as that you can create your own receiver functions with 
+# just a single smalle script.

--- a/src/pyglimer/ccp/ccp.py
+++ b/src/pyglimer/ccp/ccp.py
@@ -290,7 +290,7 @@ class CCPStack(object):
 
         # Get evenly distributed points
         qlat, qlon, qdists, sdists = gctrack(slat, slon, self.bingrid.edist/4)
-        
+
         # Get interpolation weights and rows.
         # Create SphericalNN kdtree
         snn = SphericalNN(self.coords_new[0], self.coords_new[1])

--- a/src/pyglimer/ccp/plot_utils/plot_cross_section.py
+++ b/src/pyglimer/ccp/plot_utils/plot_cross_section.py
@@ -1,6 +1,5 @@
 # Basic
 from typing import Optional, Union, Iterable
-from global_land_mask.globe import is_land
 import matplotlib
 
 # External
@@ -13,7 +12,6 @@ import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes, GeoAxesSubplot
 
 # Internal
-from pyglimer.utils.geo_utils import fix_map_extent
 from pyglimer.ccp.plot_utils.plot_map import plot_map
 from pyglimer.ccp.plot_utils.plot_line_buffer import plot_line_buffer
 from pyglimer.ccp.plot_utils.midpointcolornorm import MidpointNormalize
@@ -127,7 +125,7 @@ def plot_cross_section(
     """
 
     matplotlib.rcParams.update({'font.family': 'Arial'})
-    
+
     # Get Cross section
     slat, slon, sdists, qlat, qlon, qdists, qz, qillum, qccp, epi_area = \
         ccp.get_profile(lat, lon)
@@ -156,7 +154,7 @@ def plot_cross_section(
             geoax = plt.axes(projection=ccrs.PlateCarree())
             if mapextent is not None:
                 geoax.set_extent(mapextent)
-            
+
             plot_map(geoax)
             geoax.tick_params(labelright=False, labeltop=False)
 
@@ -171,18 +169,19 @@ def plot_cross_section(
                 illumnorm = mcolors.LogNorm(vmin=1, vmax=zqill.max())
                 illumcmap = 'magma_r'
 
-                sc = ScalarMappable(cmap=plt.get_cmap(illumcmap), norm=illumnorm)
+                sc = ScalarMappable(
+                    cmap=plt.get_cmap(illumcmap), norm=illumnorm)
                 geoax.imshow(
                     sc.to_rgba(zqill), alpha=zalpha,
                     extent=zextent, origin='lower',
-                    transform=ccrs.PlateCarree(), zorder=3
-                    )
+                    transform=ccrs.PlateCarree(), zorder=3)
 
                 # Create colorbar from artifical scalarmappable (alpha is
                 # problematic)
                 c = plt.colorbar(
                     sc,
-                    orientation='vertical', aspect=40, pad=0.025, fraction=0.05)
+                    orientation='vertical', aspect=40, pad=0.025,
+                    fraction=0.05)
                 c.set_label("Hitcount")
 
                 # Set colormap alpha manually
@@ -263,7 +262,7 @@ def plot_cross_section(
     c = plt.colorbar(
         rfim, orientation='vertical', aspect=40, pad=0.025, fraction=0.05)
     c.set_label("A", rotation=0, font='Arial')
-    plt.xlabel('Offset [$^\circ$]')
+    plt.xlabel('Offset [$^\\circ$]')
     plt.ylabel('Depth [km]')
 
     if label is not None:

--- a/src/pyglimer/database/rfh5.py
+++ b/src/pyglimer/database/rfh5.py
@@ -286,7 +286,7 @@ class RFDataBase(object):
 
             **Access only through a context manager (see below):**
 
-            >>> with RFDataBase(myfile.h5) as rfdb:
+            >>> with RFDataBase('myfile.h5') as rfdb:
             >>>     type(rfdb)  # This is a DBHandler
             <class 'pyglimer.database.rfh5.DBHandler'>
 

--- a/src/pyglimer/utils/geo_utils.py
+++ b/src/pyglimer/utils/geo_utils.py
@@ -80,7 +80,7 @@ def geodiff(lat, lon):
             np.array((lon[1:], lat[1:])).T
         )
     )
-    dists = mat[:, 0] / R_EARTH / 1000.0 / np.pi * 180 
+    dists = mat[:, 0] / R_EARTH / 1000.0 / np.pi * 180
     az = mat[:, 1]
 
     return dists, az
@@ -214,7 +214,7 @@ def gctrack(
 
     # Get tracks
     utrack = np.hstack(tracks).T
-    
+
     # Remove duplicates if there are any
     _, idx = np.unique(utrack, return_index=True, axis=0)
     utrack = utrack[np.sort(idx), :]

--- a/src/pyglimer/waveform/download.py
+++ b/src/pyglimer/waveform/download.py
@@ -139,9 +139,13 @@ def download_small_db(
     # RAM with the downloaded mseeds
     logger.info('Initialising waveform download.')
     logger.debug(f'The request string looks like this:\n\n{bulk_wav}\n')
+
+    print('clients:', clients)
     if len(clients) == 1:
+        print('how many?', len(clients))
         pu.__client__loop_wav__(clients[0], rawloc, bulk_wav, d, saveasdf, inv)
     else:
+        print('how many?', len(clients))
         Parallel(n_jobs=-1, prefer='threads')(
             delayed(pu.__client__loop_wav__)(
                 client, rawloc, bulk_wav, d, saveasdf, inv)

--- a/src/pyglimer/waveform/download.py
+++ b/src/pyglimer/waveform/download.py
@@ -127,7 +127,6 @@ def download_small_db(
                 d['net'].append(net.code)
                 d['stat'].append(stat.code)
 
-    
     # Create waveform download bulk list
     bulk_wav = pu.create_bulk_str(
         d['net'], d['stat'], '*', channel, d['startt'], d['endt'])

--- a/src/pyglimer/waveform/download.py
+++ b/src/pyglimer/waveform/download.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 '''
 :copyright:
    The PyGLImER development team (makus@gfz-potsdam.de).
@@ -10,9 +12,6 @@
 Created: Tue May 26 2019 13:31:30
 Last Modified: Friday, 8th April 2022 02:47:54 pm
 '''
-
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 
 import fnmatch
@@ -68,8 +67,11 @@ def download_small_db(
     logger.debug('Bulk stat parameters: %s' % str(bulk_stat))
 
     logger.info('Initialising station response download.')
-    # create output folder
+
+    # Create Station Output folder
     os.makedirs(statloc, exist_ok=True)
+
+    # Run parallel station loop.
     out = Parallel(n_jobs=-1, prefer='threads')(
         delayed(pu.__client__loop__)(client, statloc, bulk_stat)
         for client in clients)
@@ -130,22 +132,26 @@ def download_small_db(
     bulk_wav = pu.create_bulk_str(
         d['net'], d['stat'], '*', channel, d['startt'], d['endt'])
 
-
     if len(bulk_wav) == 0:
         logger.info('No new data found.')
         return
 
+    # Sort bulk request
+    bulk_wav.sort()
+
     # This does almost certainly need to be split up, so we don't overload the
     # RAM with the downloaded mseeds
     logger.info('Initialising waveform download.')
-    logger.debug(f'The request string looks like this:\n\n{bulk_wav}\n')
+    logger.debug('The request string looks like this:')
+    for _bw in bulk_wav:
+        logger.debug(f"{_bw}")
 
-    print('clients:', clients)
+    # Create waveform directories
+    os.makedirs(rawloc, exist_ok=True)
+
     if len(clients) == 1:
-        print('how many?', len(clients))
         pu.__client__loop_wav__(clients[0], rawloc, bulk_wav, d, saveasdf, inv)
     else:
-        print('how many?', len(clients))
         Parallel(n_jobs=-1, prefer='threads')(
             delayed(pu.__client__loop_wav__)(
                 client, rawloc, bulk_wav, d, saveasdf, inv)

--- a/src/pyglimer/waveform/preprocess.py
+++ b/src/pyglimer/waveform/preprocess.py
@@ -127,7 +127,6 @@ def preprocess(
     # Number of cores is usally a power of 2 (therefore 128)
     n_split = int(np.ceil(event_cat.count()/128))
 
-    # 
     # All error handlers rely on download via IRIS webservice.
     # However, there is a maximum number for connections (3).
     # So I don't really want to flood everything with exceptions.
@@ -166,15 +165,17 @@ def preprocess(
                     phase, rot, pol, evtcat[ii], taper_perc, taper_type,
                     model, logger, rflogger, eh, tz, ta, statloc, rawloc,
                     preproloc, rfloc, deconmeth, hc_filt, netrestr, statrestr)
-        
+
         # Use single core only
         elif client.lower() == 'single':
             out = []
             for event in tqdm(evtcat):
-                out.append(__event_loop(phase, rot, pol, event, taper_perc,
-                    taper_type, model, logger, rflogger, eh, tz,
-                    ta, statloc, rawloc, preproloc, rfloc, deconmeth,
-                    hc_filt, netrestr, statrestr))
+                out.append(
+                    __event_loop(
+                        phase, rot, pol, event, taper_perc,
+                        taper_type, model, logger, rflogger, eh, tz,
+                        ta, statloc, rawloc, preproloc, rfloc, deconmeth,
+                        hc_filt, netrestr, statrestr))
 
         else:
             raise NotImplementedError('Unknown client %s' % client)

--- a/src/pyglimer/waveform/preprocess.py
+++ b/src/pyglimer/waveform/preprocess.py
@@ -125,7 +125,7 @@ def preprocess(
     # i.e. every 100 events
 
     # Number of cores is usally a power of 2 (therefore 128)
-    n_split = int(np.ceil(event_cat.count()/128))
+    n_split = int(np.ceil(event_cat.count()/3))
 
     # All error handlers rely on download via IRIS webservice.
     # However, there is a maximum number for connections (3).

--- a/src/pyglimer/waveform/preprocess.py
+++ b/src/pyglimer/waveform/preprocess.py
@@ -125,8 +125,9 @@ def preprocess(
     # i.e. every 100 events
 
     # Number of cores is usally a power of 2 (therefore 128)
-    n_split = int(np.ceil(event_cat.count()/3))
+    n_split = int(np.ceil(event_cat.count()/128))
 
+    # 
     # All error handlers rely on download via IRIS webservice.
     # However, there is a maximum number for connections (3).
     # So I don't really want to flood everything with exceptions.
@@ -165,6 +166,16 @@ def preprocess(
                     phase, rot, pol, evtcat[ii], taper_perc, taper_type,
                     model, logger, rflogger, eh, tz, ta, statloc, rawloc,
                     preproloc, rfloc, deconmeth, hc_filt, netrestr, statrestr)
+        
+        # Use single core only
+        elif client.lower() == 'single':
+            out = []
+            for event in tqdm(evtcat):
+                out.append(__event_loop(phase, rot, pol, event, taper_perc,
+                    taper_type, model, logger, rflogger, eh, tz,
+                    ta, statloc, rawloc, preproloc, rfloc, deconmeth,
+                    hc_filt, netrestr, statrestr))
+
         else:
             raise NotImplementedError('Unknown client %s' % client)
 

--- a/src/pyglimer/waveform/preprocessh5.py
+++ b/src/pyglimer/waveform/preprocessh5.py
@@ -117,6 +117,8 @@ def preprocessh5(
     # Open ds
     fpattern = '%s.%s.h5' % (netrestr or '*', statrestr or '*')
     flist = list(glob(os.path.join(rawloc, fpattern)))
+
+    # Perform processing depending on client
     if client.lower() == 'mpi':
         from mpi4py import MPI
         comm = MPI.COMM_WORLD
@@ -133,13 +135,20 @@ def preprocessh5(
         for ii in ind:
             _preprocessh5_single(
                 phase, rot, pol, taper_perc, model, taper_type, tz, ta, rfloc,
-                deconmeth, hc_filt, logger, rflogger, flist[ii], evtcat
-            )
+                deconmeth, hc_filt, logger, rflogger, flist[ii], evtcat)
+
     elif client.lower() == 'joblib':
         Parallel(n_jobs=-1)(delayed(_preprocessh5_single)(
             phase, rot, pol, taper_perc, model, taper_type, tz, ta, rfloc,
             deconmeth, hc_filt, logger, rflogger,
             f, evtcat) for f in tqdm(flist))
+
+    elif client.lower() == 'single':
+        for f in tqdm(flist):
+            _preprocessh5_single(
+                phase, rot, pol, taper_perc, model, taper_type, tz, ta, rfloc,
+                deconmeth, hc_filt, logger, rflogger,
+                f, evtcat) 
     else:
         raise NotImplementedError(
             'Unknown multiprocessing backend %s.' % client

--- a/src/pyglimer/waveform/preprocessh5.py
+++ b/src/pyglimer/waveform/preprocessh5.py
@@ -148,7 +148,7 @@ def preprocessh5(
             _preprocessh5_single(
                 phase, rot, pol, taper_perc, model, taper_type, tz, ta, rfloc,
                 deconmeth, hc_filt, logger, rflogger,
-                f, evtcat) 
+                f, evtcat)
     else:
         raise NotImplementedError(
             'Unknown multiprocessing backend %s.' % client

--- a/src/pyglimer/waveform/request.py
+++ b/src/pyglimer/waveform/request.py
@@ -43,15 +43,16 @@ class Request(object):
     time domain receiver functions."""
 
     def __init__(
-        self, proj_dir: str, raw_subdir: str, prepro_subdir: str,
-        rf_subdir: str, statloc_subdir: str, evt_subdir: str, log_subdir: str,
-        phase: str, rot: str, deconmeth: str, starttime: UTCDateTime or str,
-        endtime: UTCDateTime or str, pol: str = 'v',
-        minmag: float or int = 5.5, event_coords: tuple = None,
-        network: str = None, station: str = None,
-        waveform_client: list = None, evtcat: str = None,
-        continue_download: bool = False, loglvl: int = logging.WARNING,
-        format: str = 'hdf5'):
+            self, proj_dir: str, raw_subdir: str, prepro_subdir: str,
+            rf_subdir: str, statloc_subdir: str, evt_subdir: str,
+            log_subdir: str, phase: str, rot: str, deconmeth: str,
+            starttime: UTCDateTime or str, endtime: UTCDateTime or str,
+            pol: str = 'v', minmag: float or int = 5.5,
+            event_coords: tuple = None,
+            network: str = None, station: str = None,
+            waveform_client: list = None, evtcat: str = None,
+            continue_download: bool = False, loglvl: int = logging.WARNING,
+            format: str = 'hdf5'):
         """
         Create object that is used to start the receiver function
         workflow.

--- a/tests/test_geoutils.py
+++ b/tests/test_geoutils.py
@@ -53,7 +53,7 @@ class TestReckon(unittest.TestCase):
         lon, lat = e2D(10, 340, 160, mind)
 
         # Compute GCTrack
-        qlat, qlon, qdists = gu.gctrack(lat, lon, d)
+        qlat, qlon, qdists, _ = gu.gctrack(lat, lon, d)
 
         # Find locations of waypoints
         pos = []
@@ -88,7 +88,7 @@ class TestReckon(unittest.TestCase):
         lon, lat = e2D(2, 340, 160, mind)
 
         # Compute GCTrack
-        qlat, qlon, qdists, updated_dists = gu.gctrack(
+        qlat, qlon, qdists, _ = gu.gctrack(
             lat, lon, d, constantdist=False)
 
         # print("Updated:")


### PR DESCRIPTION
Hi @PeterMakus,

I updated a couple of functions

* I added `client`: `'single'`, which circumvents `mpi` or   
  `joblib` usage and just does everything on a single 
  core. For very small examples, such as creating RF's 
  for for a single station for 6 months, this comes with 
  a lot fewer problems.
* `examples/tutorials` now contains 3 new files, a tutorial for SAC database tutorial for HDF5 database, `README.rst`, which defines the content of the tutorial page. Check `pygmt` docs for reference. These scripts are executed as part of the `make html` process. If you only want to see the docs rendered and keep current figures use `make html-noplot`.

The tutorials are not exactly fast with a single core, but I think that should be fine. This is such a small example anyways.

I will make the pull request but we'll see of there are conflicts



After the `no-logging` tip, all tests passed locally.